### PR TITLE
Portable version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "rustodoro"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustodoro"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A simple CLI pomodoro timer application"
 repository = "https://github.com/Terror-Byte/rustodoro"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,11 @@ toml = "0.8.13"
 serde = { version = "1.0.203", features = ["derive"] }
 crossterm = "0.27.0"
 clap = { version = "4.5.6", features = ["derive"] }
-directories = "6.0.0"
+directories = { version = "6.0.0", optional = true }
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 chrono = "0.4.38"
 notify-rust = "4.14.0"
+
+[features]
+default = ["dep:directories"]
+portable = []

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,13 +116,11 @@ impl Default for Config {
 
 #[cfg(all(not(debug_assertions), not(feature = "portable")))]
 pub fn get_config_path() -> Option<String> {
-    if !cfg!(debug_assertions) && !cfg!(feature = "portable") {
-        if let Some(proj_dirs) = ProjectDirs::from("com", "TerrorByte", "Rustodoro") {
-            let mut config_dir = proj_dirs.config_dir().to_path_buf();
-            config_dir.push(CONFIG_NAME);
-            if let Some(config_path) = config_dir.to_str() {
-                return Some(config_path.to_string());
-            }
+    if let Some(proj_dirs) = ProjectDirs::from("com", "TerrorByte", "Rustodoro") {
+        let mut config_dir = proj_dirs.config_dir().to_path_buf();
+        config_dir.push(CONFIG_NAME);
+        if let Some(config_path) = config_dir.to_str() {
+            return Some(config_path.to_string());
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,12 +3,14 @@ use crate::args::{
     SetShortBreakTimeArgs, SetWorkTimeArgs, ToSeconds,
 };
 use crate::error::{Error, Result};
+#[cfg(all(not(debug_assertions), not(feature = "portable")))]
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
+#[cfg(any(debug_assertions, feature = "portable"))]
+use std::env;
 use std::fs;
 
 const CONFIG_NAME: &str = "config.toml";
-const RELATIVE_CONFIG_PATH: &str = "./config.toml";
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct Config {
@@ -112,16 +114,42 @@ impl Default for Config {
     }
 }
 
-pub fn get_config_path() -> String {
-    if !cfg!(debug_assertions) {
+#[cfg(all(not(debug_assertions), not(feature = "portable")))]
+pub fn get_config_path() -> Option<String> {
+    if !cfg!(debug_assertions) && !cfg!(feature = "portable") {
         if let Some(proj_dirs) = ProjectDirs::from("com", "TerrorByte", "Rustodoro") {
-            if let Some(directory) = proj_dirs.config_dir().to_str() {
-                let mut config_path = String::from(directory);
-                config_path.push_str("/");
-                config_path.push_str(CONFIG_NAME);
-                return config_path;
+            let mut config_dir = proj_dirs.config_dir().to_path_buf();
+            config_dir.push(CONFIG_NAME);
+            if let Some(config_path) = config_dir.to_str() {
+                return Some(config_path.to_string());
             }
         }
     }
-    String::from(RELATIVE_CONFIG_PATH)
+
+    None
+}
+
+#[cfg(all(not(debug_assertions), feature = "portable"))]
+pub fn get_config_path() -> Option<String> {
+    if let Ok(mut exe_dir) = env::current_exe() {
+        exe_dir.pop();
+        exe_dir.push(CONFIG_NAME);
+        if let Some(config_path) = exe_dir.to_str() {
+            return Some(config_path.to_string());
+        }
+    }
+
+    None
+}
+
+#[cfg(all(debug_assertions, not(feature = "portable")))]
+pub fn get_config_path() -> Option<String> {
+    if let Ok(mut pwd) = env::current_dir() {
+        pwd.push(CONFIG_NAME);
+        if let Some(config_path) = pwd.to_str() {
+            return Some(config_path.to_string());
+        }
+    }
+
+    None
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,10 @@
 use chrono::{Datelike, Local, NaiveDate, NaiveTime, TimeZone, Weekday};
+#[cfg(all(not(debug_assertions), not(feature = "portable")))]
 use directories::ProjectDirs;
 use rusqlite::{Connection, OptionalExtension};
+#[cfg(any(debug_assertions, feature = "portable"))]
+use std::env;
+#[cfg(all(not(debug_assertions), not(feature = "portable")))]
 use std::fs;
 use std::time::SystemTime;
 
@@ -9,7 +13,6 @@ use crate::error::{Error, Result};
 use crate::timer::TimerType;
 
 const DATABASE_NAME: &str = "rustodoro.db";
-const RELATIVE_DB_PATH: &str = "./rustodoro.db";
 
 // Table creation queries
 const CREATE_POMODORO_TABLE_QUERY: &str = "CREATE TABLE IF NOT EXISTS pomodoros (
@@ -46,7 +49,12 @@ pub fn save_session_to_db(start_time: u64, end_time: u64, session_type: TimerTyp
         TimerType::LongBreak => (CREATE_LONG_BREAK_TABLE_QUERY, INSERT_LONG_BREAK_QUERY),
     };
 
-    let conn = Connection::open(get_database_path()?)?;
+    let conn = Connection::open(
+        get_database_path().ok_or(Error::PathError(
+            "Failed to get database path. Either it does not exist, or it could not be created"
+                .to_string(),
+        ))?,
+    )?;
 
     // Create table if it doesn't exist
     conn.execute(create_table_query, ())?;
@@ -73,7 +81,12 @@ pub fn get_sessions(
 }
 
 pub fn get_most_recent_session(session_type: TimerType) -> Result<Option<(u64, u64)>> {
-    let conn = Connection::open(get_database_path()?)?;
+    let conn = Connection::open(
+        get_database_path().ok_or(Error::PathError(
+            "Failed to get database path. Either it does not exist, or it could not be created"
+                .to_string(),
+        ))?,
+    )?;
 
     let start_timestamp = get_start_of_day_timestamp()?;
     let end_timestamp = get_end_of_day_timestamp()?;
@@ -106,7 +119,12 @@ fn get_sessions_internal(
     start_timestamp: i64,
     end_timestamp: i64,
 ) -> Result<SessionVector> {
-    let conn = Connection::open(get_database_path()?)?;
+    let conn = Connection::open(
+        get_database_path().ok_or(Error::PathError(
+            "Failed to get database path. Either it does not exist, or it could not be created"
+                .to_string(),
+        ))?,
+    )?;
 
     let table_name = match session_type {
         TimerType::Work => POMODORO_TABLE_NAME,
@@ -321,21 +339,50 @@ fn get_end_of_month_timestamp() -> Result<i64> {
 }
 
 // Utility Functions
-fn get_database_path() -> Result<String> {
-    if !cfg!(debug_assertions) {
-        if let Some(proj_dirs) = ProjectDirs::from("com", "TerrorByte", "Rustodoro") {
-            if !proj_dirs.data_dir().exists() {
-                fs::create_dir(proj_dirs.data_dir())?;
-            }
-            if let Some(directory) = proj_dirs.data_dir().to_str() {
-                let mut dbpath = String::from(directory);
-                dbpath.push_str("/");
-                dbpath.push_str(DATABASE_NAME);
-                return Ok(dbpath);
+#[cfg(all(not(debug_assertions), not(feature = "portable")))]
+// Don't really like how we're hiding the error in this, but how do we allow options and results?
+// Can we move the directory creation to a new function?
+fn get_database_path() -> Option<String> {
+    if let Some(proj_dirs) = ProjectDirs::from("com", "TerrorByte", "Rustodoro") {
+        if !proj_dirs.data_dir().exists() {
+            if let Err(_) = fs::create_dir(proj_dirs.data_dir()) {
+                return None;
             }
         }
+
+        let mut database_dir = proj_dirs.data_dir().to_path_buf();
+        database_dir.push(DATABASE_NAME);
+        if let Some(database_path) = database_dir.to_str() {
+            return Some(database_path.to_string());
+        }
     }
-    Ok(String::from(RELATIVE_DB_PATH))
+
+    None
+}
+
+#[cfg(all(not(debug_assertions), feature = "portable"))]
+fn get_database_path() -> Option<String> {
+    if let Ok(mut exe_dir) = env::current_exe() {
+        exe_dir.pop();
+        exe_dir.push(DATABASE_NAME);
+        if let Some(database_path) = exe_dir.to_str() {
+            return Some(database_path.to_string());
+        }
+    }
+
+    None
+}
+
+#[cfg(all(debug_assertions, not(feature = "portable")))]
+fn get_database_path() -> Option<String> {
+    if let Ok(mut pwd) = env::current_dir() {
+        pwd.push(DATABASE_NAME);
+        if let Some(database_path) = pwd.to_str() {
+            return Some(database_path.to_string());
+        }
+    }
+
+    None
 }
 
 // TODO: This is a duplicate of the function in timer.rs, do we want to make that one public or

--- a/src/db.rs
+++ b/src/db.rs
@@ -340,8 +340,6 @@ fn get_end_of_month_timestamp() -> Result<i64> {
 
 // Utility Functions
 #[cfg(all(not(debug_assertions), not(feature = "portable")))]
-// Don't really like how we're hiding the error in this, but how do we allow options and results?
-// Can we move the directory creation to a new function?
 fn get_database_path() -> Option<String> {
     if let Some(proj_dirs) = ProjectDirs::from("com", "TerrorByte", "Rustodoro") {
         if !proj_dirs.data_dir().exists() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,7 @@ pub enum Error {
     DateTimeError(String),
     NaiveTimeError(String),
     NotifyRustError(notify_rust::error::Error),
+    PathError(String),
 }
 
 impl fmt::Debug for Error {
@@ -26,6 +27,7 @@ impl fmt::Debug for Error {
             Error::DateTimeError(msg) => write!(f, "Date Time Parse Error - {}", msg),
             Error::NaiveTimeError(msg) => write!(f, "NaiveTime Error - {}", msg),
             Error::NotifyRustError(e) => write!(f, "Notification Error - {}", e),
+            Error::PathError(e) => write!(f, "Path Error - {}", e),
         }
     }
 }
@@ -42,6 +44,7 @@ impl fmt::Display for Error {
             Error::DateTimeError(msg) => write!(f, "Date Time Parse Error - {}", msg),
             Error::NaiveTimeError(msg) => write!(f, "NaiveTime Error - {}", msg),
             Error::NotifyRustError(e) => write!(f, "Notification Error - {}", e),
+            Error::PathError(e) => write!(f, "Path Error - {}", e),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod timer;
 use args::{RustodoroArgs, RustodoroCommand};
 use clap::Parser;
 use config::Config;
-use error::Result;
+use error::{Error, Result};
 use notify_rust::{Hint, Notification, Urgency};
 use timer::TimerType;
 
@@ -16,7 +16,8 @@ use crate::args::TimeSpan;
 
 fn main() -> Result<()> {
     // TODO: For the commands where we're modifying the config, what sort of user feedback do we want to let the user know the command executed successfully?
-    let config_path = config::get_config_path();
+    let config_path = config::get_config_path()
+        .ok_or(Error::ConfigError("Failed to get config path".to_string()))?;
     let config = Config::load(config_path.as_str())?;
     let args: RustodoroArgs = RustodoroArgs::parse();
     match args.command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use crate::args::TimeSpan;
 fn main() -> Result<()> {
     // TODO: For the commands where we're modifying the config, what sort of user feedback do we want to let the user know the command executed successfully?
     let config_path = config::get_config_path()
-        .ok_or(Error::ConfigError("Failed to get config path".to_string()))?;
+        .ok_or(Error::PathError("Failed to get config path".to_string()))?;
     let config = Config::load(config_path.as_str())?;
     let args: RustodoroArgs = RustodoroArgs::parse();
     match args.command {


### PR DESCRIPTION
* Added `portable` feature flag
  * When compiled with this flag, rustodoro will store its config and database files relative to itself, and not in XDG directories
  * Ensured that only the necessary dependencies are compiled with the portable and non-portable versions of rustodoro
* There are now 3 versions of `config::get_config_path()` and `db::get_database_path`, which are conditionally compiled based on whether rustodoro is running in debug, release, or release with the portable feature flag
* Upped project version to 0.3.0 in preparation for next release