### PR TITLE
Optional timer args

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -4,6 +4,10 @@ pub trait ToSeconds {
     fn to_seconds(&self) -> u16; // TODO: Make this generic instead of a solid u16 type?
 }
 
+pub trait HasValue {
+    fn has_value(&self) -> bool;
+}
+
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None)]
 pub struct RustodoroArgs {
@@ -15,24 +19,24 @@ pub struct RustodoroArgs {
 pub enum RustodoroCommand {
     /// Start a work timer - If no arguments are passed, the work_time property from
     /// the config will be used
-    Work(TimerArgs),
+    Work(RunTimerArgs),
 
     /// Start a short break timer - If no arguments are passed, the short_break_time
     /// property from the config will be used
-    ShortBreak(TimerArgs),
+    ShortBreak(RunTimerArgs),
 
     /// Start a long break timer - If no arguments are passed, the long_break_time
     /// property from the config will be used
-    LongBreak(TimerArgs),
+    LongBreak(RunTimerArgs),
 
     /// Configure the work timer
-    SetWorkTime(SetWorkTimeArgs),
+    SetWorkTime(ConfigureTimerArgs),
 
     /// Configure the short break timer
-    SetShortBreakTime(SetShortBreakTimeArgs),
+    SetShortBreakTime(ConfigureTimerArgs),
 
     /// Configure the long break timer
-    SetLongBreakTime(SetLongBreakTimeArgs),
+    SetLongBreakTime(ConfigureTimerArgs),
 
     /// Configure the amount of pomodoros (work stints) to complete for a long break
     SetPomodorosToLongBreak(SetPomodorosToLongBreakArgs),
@@ -54,45 +58,23 @@ pub enum RustodoroCommand {
 }
 
 #[derive(Debug, Args)]
-pub struct TimerArgs {
-    /// Minutes component of the work timer
+pub struct RunTimerArgs {
+    /// Minutes component of the timer
     #[arg(short, long)]
     pub minutes: Option<u16>,
 
-    /// Seconds component of the work timer
+    /// Seconds component of the timer
     #[arg(short, long)]
     pub seconds: Option<u16>,
 }
 
 #[derive(Debug, Args)]
-pub struct SetWorkTimeArgs {
-    /// Minutes component of the work timer
+pub struct ConfigureTimerArgs {
+    /// Minutes component of the timer
     #[arg(short, long)]
     pub minutes: Option<u16>,
 
-    /// Seconds component of the work timer
-    #[arg(short, long)]
-    pub seconds: Option<u16>,
-}
-
-#[derive(Debug, Args)]
-pub struct SetShortBreakTimeArgs {
-    /// Minutes component of the short break timer
-    #[arg(short, long)]
-    pub minutes: Option<u16>,
-
-    /// Seconds component of the short break timer
-    #[arg(short, long)]
-    pub seconds: Option<u16>,
-}
-
-#[derive(Debug, Args)]
-pub struct SetLongBreakTimeArgs {
-    /// Minutes component of the long break timer
-    #[arg(short, long)]
-    pub minutes: Option<u16>,
-
-    /// Seconds component of the long break timer
+    /// Seconds component of the timer
     #[arg(short, long)]
     pub seconds: Option<u16>,
 }
@@ -139,13 +121,29 @@ pub struct SetDesktopNotificationsArgs {
     pub desktop_notifications: bool,
 }
 
-impl TimerArgs {
-    pub fn has_value(&self) -> bool {
+impl ToSeconds for RunTimerArgs {
+    fn to_seconds(&self) -> u16 {
+        let mut time_in_seconds: u16 = 0;
+
+        if let Some(minutes) = self.minutes {
+            time_in_seconds += minutes * 60;
+        }
+
+        if let Some(seconds) = self.seconds {
+            time_in_seconds += seconds;
+        }
+
+        time_in_seconds
+    }
+}
+
+impl HasValue for RunTimerArgs {
+    fn has_value(&self) -> bool {
         self.minutes.is_some() || self.seconds.is_some()
     }
 }
 
-impl ToSeconds for TimerArgs {
+impl ToSeconds for ConfigureTimerArgs {
     fn to_seconds(&self) -> u16 {
         let mut time_in_seconds: u16 = 0;
 
@@ -161,50 +159,8 @@ impl ToSeconds for TimerArgs {
     }
 }
 
-impl ToSeconds for SetWorkTimeArgs {
-    fn to_seconds(&self) -> u16 {
-        let mut time_in_seconds: u16 = 0;
-
-        if let Some(minutes) = self.minutes {
-            time_in_seconds += minutes * 60;
-        }
-
-        if let Some(seconds) = self.seconds {
-            time_in_seconds += seconds;
-        }
-
-        time_in_seconds
-    }
-}
-
-impl ToSeconds for SetShortBreakTimeArgs {
-    fn to_seconds(&self) -> u16 {
-        let mut time_in_seconds: u16 = 0;
-
-        if let Some(minutes) = self.minutes {
-            time_in_seconds += minutes * 60;
-        }
-
-        if let Some(seconds) = self.seconds {
-            time_in_seconds += seconds;
-        }
-
-        time_in_seconds
-    }
-}
-
-impl ToSeconds for SetLongBreakTimeArgs {
-    fn to_seconds(&self) -> u16 {
-        let mut time_in_seconds: u16 = 0;
-
-        if let Some(minutes) = self.minutes {
-            time_in_seconds += minutes * 60;
-        }
-
-        if let Some(seconds) = self.seconds {
-            time_in_seconds += seconds;
-        }
-
-        time_in_seconds
+impl HasValue for ConfigureTimerArgs {
+    fn has_value(&self) -> bool {
+        self.minutes.is_some() || self.seconds.is_some()
     }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -13,14 +13,17 @@ pub struct RustodoroArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum RustodoroCommand {
-    /// Start a work timer
-    Work,
+    /// Start a work timer - If no arguments are passed, the work_time property from
+    /// the config will be used
+    Work(TimerArgs),
 
-    /// Start a short break timer
-    ShortBreak,
+    /// Start a short break timer - If no arguments are passed, the short_break_time
+    /// property from the config will be used
+    ShortBreak(TimerArgs),
 
-    /// Start a long break timer
-    LongBreak,
+    /// Start a long break timer - If no arguments are passed, the long_break_time
+    /// property from the config will be used
+    LongBreak(TimerArgs),
 
     /// Configure the work timer
     SetWorkTime(SetWorkTimeArgs),
@@ -48,6 +51,17 @@ pub enum RustodoroCommand {
 
     /// Display the long breaks from today, this week or this month
     DisplayLongBreaks(DisplayLongBreaksArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct TimerArgs {
+    /// Minutes component of the work timer
+    #[arg(short, long)]
+    pub minutes: Option<u16>,
+
+    /// Seconds component of the work timer
+    #[arg(short, long)]
+    pub seconds: Option<u16>,
 }
 
 #[derive(Debug, Args)]
@@ -123,6 +137,28 @@ pub struct DisplayLongBreaksArgs {
 pub struct SetDesktopNotificationsArgs {
     #[arg(action = ArgAction::Set)]
     pub desktop_notifications: bool,
+}
+
+impl TimerArgs {
+    pub fn has_value(&self) -> bool {
+        self.minutes.is_some() || self.seconds.is_some()
+    }
+}
+
+impl ToSeconds for TimerArgs {
+    fn to_seconds(&self) -> u16 {
+        let mut time_in_seconds: u16 = 0;
+
+        if let Some(minutes) = self.minutes {
+            time_in_seconds += minutes * 60;
+        }
+
+        if let Some(seconds) = self.seconds {
+            time_in_seconds += seconds;
+        }
+
+        time_in_seconds
+    }
 }
 
 impl ToSeconds for SetWorkTimeArgs {

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,7 +1,7 @@
 use clap::{ArgAction, Args, Parser, Subcommand};
 
 pub trait ToSeconds {
-    fn to_seconds(&self) -> u16; // TODO: Make this generic instead of a solid u16 type?
+    fn to_seconds(&self) -> u16;
 }
 
 pub trait HasValue {
@@ -137,12 +137,6 @@ impl ToSeconds for RunTimerArgs {
     }
 }
 
-impl HasValue for RunTimerArgs {
-    fn has_value(&self) -> bool {
-        self.minutes.is_some() || self.seconds.is_some()
-    }
-}
-
 impl ToSeconds for ConfigureTimerArgs {
     fn to_seconds(&self) -> u16 {
         let mut time_in_seconds: u16 = 0;
@@ -156,6 +150,12 @@ impl ToSeconds for ConfigureTimerArgs {
         }
 
         time_in_seconds
+    }
+}
+
+impl HasValue for RunTimerArgs {
+    fn has_value(&self) -> bool {
+        self.minutes.is_some() || self.seconds.is_some()
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use crate::args::{
-    SetDesktopNotificationsArgs, SetLogToDBArgs, SetLongBreakTimeArgs, SetPomodorosToLongBreakArgs,
-    SetShortBreakTimeArgs, SetWorkTimeArgs, ToSeconds,
+    ConfigureTimerArgs, HasValue, SetDesktopNotificationsArgs, SetLogToDBArgs,
+    SetPomodorosToLongBreakArgs, ToSeconds,
 };
 use crate::error::{Error, Result};
 #[cfg(all(not(debug_assertions), not(feature = "portable")))]
@@ -40,7 +40,13 @@ impl Config {
         Ok(Config::default())
     }
 
-    pub fn set_work_time(self, args: SetWorkTimeArgs) -> Result<Config> {
+    pub fn set_work_time(self, args: ConfigureTimerArgs) -> Result<Config> {
+        if !args.has_value() {
+            return Err(Error::ConfigError(
+                "No arguments have been passed".to_string(),
+            ));
+        }
+
         let work_time = args.to_seconds();
         if work_time == 0 {
             return Err(Error::ConfigError(
@@ -51,7 +57,13 @@ impl Config {
         Ok(Config { work_time, ..self })
     }
 
-    pub fn set_short_break_time(self, args: SetShortBreakTimeArgs) -> Result<Config> {
+    pub fn set_short_break_time(self, args: ConfigureTimerArgs) -> Result<Config> {
+        if !args.has_value() {
+            return Err(Error::ConfigError(
+                "No arguments have been passed".to_string(),
+            ));
+        }
+
         let short_break_time = args.to_seconds();
         if short_break_time == 0 {
             return Err(Error::ConfigError(
@@ -65,7 +77,13 @@ impl Config {
         })
     }
 
-    pub fn set_long_break_time(self, args: SetLongBreakTimeArgs) -> Result<Config> {
+    pub fn set_long_break_time(self, args: ConfigureTimerArgs) -> Result<Config> {
+        if !args.has_value() {
+            return Err(Error::ConfigError(
+                "No arguments have been passed".to_string(),
+            ));
+        }
+
         let long_break_time = args.to_seconds();
         if long_break_time == 0 {
             return Err(Error::ConfigError(

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use error::{Error, Result};
 use notify_rust::{Hint, Notification, Urgency};
 use timer::TimerType;
 
-use crate::args::TimeSpan;
+use crate::args::{TimeSpan, ToSeconds};
 
 fn main() -> Result<()> {
     // TODO: For the commands where we're modifying the config, what sort of user feedback do we want to let the user know the command executed successfully?
@@ -21,8 +21,14 @@ fn main() -> Result<()> {
     let config = Config::load(config_path.as_str())?;
     let args: RustodoroArgs = RustodoroArgs::parse();
     match args.command {
-        RustodoroCommand::Work => {
-            let (start_time, end_time) = timer::run_timer(config.work_time, TimerType::Work)?;
+        RustodoroCommand::Work(args) => {
+            let work_time = if args.has_value() {
+                args.to_seconds()
+            } else {
+                config.work_time
+            };
+
+            let (start_time, end_time) = timer::run_timer(work_time, TimerType::Work)?;
             if config.log_to_db {
                 db::save_session_to_db(start_time, end_time, TimerType::Work)?;
 
@@ -67,8 +73,14 @@ fn main() -> Result<()> {
                     .show()?;
             }
         }
-        RustodoroCommand::ShortBreak => {
-            let (start_time, end_time) = timer::run_timer(config.work_time, TimerType::ShortBreak)?;
+        RustodoroCommand::ShortBreak(args) => {
+            let short_break_time = if args.has_value() {
+                args.to_seconds()
+            } else {
+                config.short_break_time
+            };
+
+            let (start_time, end_time) = timer::run_timer(short_break_time, TimerType::ShortBreak)?;
             if config.log_to_db {
                 db::save_session_to_db(start_time, end_time, TimerType::ShortBreak)?;
             }
@@ -82,8 +94,14 @@ fn main() -> Result<()> {
                     .show()?;
             }
         }
-        RustodoroCommand::LongBreak => {
-            let (start_time, end_time) = timer::run_timer(config.work_time, TimerType::LongBreak)?;
+        RustodoroCommand::LongBreak(args) => {
+            let long_break_time = if args.has_value() {
+                args.to_seconds()
+            } else {
+                config.long_break_time
+            };
+
+            let (start_time, end_time) = timer::run_timer(long_break_time, TimerType::LongBreak)?;
             if config.log_to_db {
                 db::save_session_to_db(start_time, end_time, TimerType::LongBreak)?;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use error::{Error, Result};
 use notify_rust::{Hint, Notification, Urgency};
 use timer::TimerType;
 
-use crate::args::{TimeSpan, ToSeconds};
+use crate::args::{HasValue, TimeSpan, ToSeconds};
 
 fn main() -> Result<()> {
     // TODO: For the commands where we're modifying the config, what sort of user feedback do we want to let the user know the command executed successfully?


### PR DESCRIPTION
* Timer commands now accept optional arguments, allowing the user to run timers of variable length without having to constantly change the config values
  * e.g. running `rustodoro work` will run a work timer of the length specified in the config, whilst `rustodoro work -m 30 -s 10` will ignore whatever value is specified in the config and will instead run a timer for 30 minutes and 10 seconds
* Combined the structs `SetWorkTimeArgs`, `SetShortBreakTimeArgs` and `SetLongBreakTimerArgs` into `ConfigureTimerArgs`
  * These structs all had the same members and performed the same function, so it wasn't really necessary to have them be separate anymore